### PR TITLE
Fix/idtype

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -20,11 +20,12 @@ exports.track = function (msg, settings){
   var referrer = msg.proxy('context.referrer.id');
   var sdkVersion = app.name + '-sdk-' + firstLetterOfOS(device) + 'v' + app.build;
   var conversionLabel = exports.getConversionLabel(msg.event(), events)
+  var idType = getIdType(device);
 
   return reject({
     label: conversionLabel,
     rdid: device.advertisingId,
-    idtype: 'advertisingid',
+    idtype: idType,
     lat: 0,
     bundleid: app.namespace,
     appversion: app.version,
@@ -35,6 +36,16 @@ exports.track = function (msg, settings){
     currency_code: msg.currency()
   });
 };
+
+/**
+ * The idtype parameter should be idfa for iOS and advertisingid for android
+ *
+ * @param {Object} device
+ */
+
+function getIdType (device) {
+  return (device.type === 'ios') ? 'idfa' : 'advertisingid';
+}
 
 /**
  * The endpoint needs an sdk version field which needs the first letter of the device type

--- a/test/fixtures/track-application-installed-android.json
+++ b/test/fixtures/track-application-installed-android.json
@@ -1,0 +1,60 @@
+{
+"input": {
+  "type": "track",
+  "event": "Application Installed",
+  "userId": "user-id",
+  "properties": {},
+  "timestamp": "2015-11-09",
+  "context": {
+    "ip": "10.0.0.2",
+    "app": { 
+      "namespace": "com.segment.TestApp",
+      "name": "Segment Test",
+      "version": "1.0.0",
+      "build": "1.0.0"
+    },
+    "network": { "carrier": "some-carrier" },
+    "locale": "en-US",
+    "library": {
+      "name": "analytics-android",
+      "version": "4.0.3"
+    },
+    "referrer": {
+      "type": "iad",
+      "id": "some-id"
+    },
+    "os": {
+      "name": "Android",
+      "version": "5.0"
+    },
+    "timezone": "America/Los_Angeles",
+    "screen": {
+      "density": 3,
+      "width": 1080,
+      "height": 1920
+    },
+    "userAgent": "Dalvik/2.1.0 (Linux; U; Android 5.0; SM-N900P Build/LRX21V)",
+    "device": {
+      "id": "987b82fe0441db85",
+      "manufacturer": "samsung",
+      "model": "SM-N900P",
+      "name": "hltespr",
+      "advertisingId": "29d7493b-bc9a-4fa9-939b-367c26ac0ec4",
+      "adTrackingEnabled": false,
+      "type": "android"
+    }
+  }
+},
+"output": {
+  "label": "824NCNfly2cQ4ZPN4gM",
+  "rdid": "29d7493b-bc9a-4fa9-939b-367c26ac0ec4",
+  "idtype": "advertisingid",
+  "lat": "0",
+  "bundleid": "com.segment.TestApp",
+  "appversion": "1.0.0",
+  "osversion": "5.0",
+  "sdkversion": "1.0.0",
+  "referrer": "some-id",
+  "currency_code": "USD"
+}
+}

--- a/test/fixtures/track-application-installed-ios.json
+++ b/test/fixtures/track-application-installed-ios.json
@@ -34,7 +34,7 @@
   "output": {
     "label": "824NCNfly2cQ4ZPN4gM",
     "rdid": "159358",
-    "idtype": "advertisingid",
+    "idtype": "idfa",
     "lat": "0",
     "bundleid": "com.segment.TestApp",
     "appversion": "1.0.0",

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -30,7 +30,7 @@
   "output": {
     "label": "L5vqCITpy2cQ4ZPN4gM",
     "rdid": "159358",
-    "idtype": "advertisingid",
+    "idtype": "idfa",
     "lat": "0",
     "bundleid": "com.segment.TestApp",
     "appversion": "1.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -84,9 +84,13 @@ describe('Google AdWords', function(){
       });
     });
 
-    describe('Application Opened', function(){
-      it('should map Application Opened', function(){
-        test.maps('track-application-opened');
+    describe('Application Installed', function(){
+      it('should map Application Installed for iOS', function(){
+        test.maps('track-application-installed-ios');
+      });
+
+      it('should map Application Installed for android', function(){
+        test.maps('track-application-installed-android');
       });
     });
 
@@ -106,9 +110,21 @@ describe('Google AdWords', function(){
         });
     });
 
-    it('should track Opened Application correctly', function(done){
+    it('should track Application Installed correctly for iOS', function(done){
       var spy = sandbox.spy(googleAdWords, 'get');
-      var json = test.fixture('track-application-opened');
+      var json = test.fixture('track-application-installed-ios');
+      test
+        .track(json.input)
+        .query(json.output)
+        .expects(200, function(err, res){
+          assert(spy.calledWithExactly('1012091361/'));
+          done();
+        });
+    });
+
+    it('should track Application Installed correctly for android', function(done){
+      var spy = sandbox.spy(googleAdWords, 'get');
+      var json = test.fixture('track-application-installed-android');
       test
         .track(json.input)
         .query(json.output)


### PR DESCRIPTION
We had `advertisingid` hardcoded as the `idtype` parameter which is valid for android but for iOS devices, Google adwords expects `idfa` for that field. This PR fixes this and adds specific iOS and android tests as well as fixing the naming of the test-fixtures files.

@f2prateek @sperand-io @jgershen 
