### PR TITLE
allow standalone remarketing tags EPD-489

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.2.0 / 2017-01-05
+==================
+
+  * Support sending standalone remarketing tags 
+
 2.1.0 / 2016-12-01
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,6 @@ var mapper = require('./mapper');
 var AdWords = module.exports = integration('AdWords')
   .endpoint('https://www.googleadservices.com/pagead/conversion/')
   .channels(['server'])
-  .ensure('settings.events')
   .mapper(mapper)
   .retries(2);
 
@@ -25,18 +24,17 @@ AdWords.ensure(function(msg, settings){
   var os = msg.proxy('context.os') || {};
   var conversionId = settings.conversionId;
   var conversionLabel = mapper.getConversionLabel(msg.event(), settings.events);
-  var remarketing = settings.remarketing;
+  var remarketingEvent = mapper.getRemarketingEvent(msg.event(), settings.whitelist);
 
   if (!device.advertisingId) return this.invalid('All calls must have an advertisingId');
   if (!app.namespace) return this.invalid('All calls must have an App Namespace');
   if (!app.version) return this.invalid('All calls must have an App Version');
   if (!os.version) return this.invalid('All calls must have an OS Version');
   if (!device.type) return this.invalid('All calls must have a Device Type');
-  if (!conversionId) return this.invalid('All calls must have an conversionId');
-  if (!conversionLabel) return this.invalid('All calls must have a conversionLabel');
-  // Remarketing tags will only be sent for mapped events because that is how we do it
-  // in client side. Also if otherwise, we'd be sending every event as remarketing tags
-  // and flood people's adwords account with unwanted remarketing properties!
+  if (!conversionId) return this.invalid('All calls must have a conversionId');
+  if (!conversionLabel && !remarketingEvent) return this.invalid('All calls must have at least a mapped conversion label or a whitelisted remarketing event');
+  // If you have remarketing setting enabled, we will send additional remarketing pings for all your conversion labels
+  // If you include a whitelisted non conversion events to send as remarketing pings we can send remarketing pings without a conversion label
   return;
 });
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -14,54 +14,29 @@ var each = require('@ndhoule/each');
 
 exports.track = function (msg, settings){
   var events = settings.events;
-  var conversionLabel = exports.getConversionLabel(msg.event(), events)
+  var whitelistedRemarketingEvent = exports.getRemarketingEvent(msg.event(), settings.whitelist);
+  var conversionLabel = exports.getConversionLabel(msg.event(), events);
   var remarketing = settings.remarketing;
   var ret = [];
 
   if (conversionLabel) {
-    var device = msg.proxy('context.device');
-    var app = msg.proxy('context.app');
-    var os = msg.proxy('context.os');
-    var referrer = msg.proxy('context.referrer.id');
-    var sdkVersion = app.name + '-sdk-' + firstLetterOfOS(device) + 'v' + app.build;
-    var idType = getIdType(device);
-    var limitedAdTracking = device.adTrackingEnabled ? 1 : 0;
-    var conversion = {
-      label: conversionLabel,
-      rdid: device.advertisingId,
-      idtype: idType,
-      lat: limitedAdTracking,
-      bundleid: app.namespace,
-      appversion: app.version,
-      osversion: os.version,
-      sdkversion: app.build,
-      value: msg.revenue() || 0,
-      currency_code: msg.currency() // defaults to 'USD'
-    };
-
-    if (referrer) conversion.referrer = referrer;
-
+    var conversion = formatConversionTag(msg);
+    conversion.label = conversionLabel;
     ret.push(conversion);
 
     // Just like client side, we only send remarketing tags for mapped events
     if (remarketing) {
-      var remarketingTag = {
-        bundleid: app.namespace,
-        rdid: device.advertisingId,
-        idtype: idType,
-        lat: limitedAdTracking,
-        remarketing_only: 1,
-        appversion: app.version,
-        osversion: os.version
-      };
-
-      // custom properties to remarket with must be prefixed with `data.` property
-      each(function(value, key) {
-        remarketingTag['data.' + key] = value;
-      }, msg.properties());
-
+      var remarketingTag = formatRemarketingTag(msg);
       ret.push(remarketingTag);
     }
+  }
+
+  // You can still send remarketing pings by itself if you have whitelisted a certain event to do so
+  // Noop if we already sent the same remarketing tag above in case customer
+  // accidentally whitelists an event they already mapped as a conversion label
+  if (whitelistedRemarketingEvent && !remarketingTag) {
+    var whitelistedRemarketingTag = formatRemarketingTag(msg);
+    ret.push(whitelistedRemarketingTag);
   }
 
   return ret;
@@ -102,3 +77,77 @@ exports.getConversionLabel = function(eventName, events) {
     return events[eventName];
   }
 };
+
+/**
+ * You can whitelist Segment events to be sent as standalone remarketing tags
+ * Exposing this with exports because we need to use it in lib/index.js's ensure block
+ *
+ * @param {String} eventName
+ * @param {Array} events
+ * @return {Boolean}
+ */
+
+exports.getRemarketingEvent = function(eventName, events) {
+  if (events.indexOf(eventName) > -1) return true;
+};
+
+/**
+ * Generate a conversion tag payload
+ *
+ * @param {Object} msg
+ * @param {Object} ret
+ * @api private
+ */
+
+function formatConversionTag(msg) {
+  var device = msg.proxy('context.device');
+  var app = msg.proxy('context.app');
+  var os = msg.proxy('context.os');
+  var referrer = msg.proxy('context.referrer.id');
+  var sdkVersion = app.name + '-sdk-' + firstLetterOfOS(device) + 'v' + app.build;
+  var ret = {
+    rdid: device.advertisingId,
+    idtype: getIdType(device),
+    lat: device.adTrackingEnabled ? 1 : 0,
+    bundleid: app.namespace,
+    appversion: app.version,
+    osversion: os.version,
+    sdkversion: app.build,
+    value: msg.revenue() || 0,
+    currency_code: msg.currency() // defaults to 'USD'
+  };
+
+  if (referrer) ret.referrer = referrer;
+
+  return ret;
+}
+/**
+ * Generate a remarketing tag payload
+ *
+ * @param {Object} msg
+ * @param {Object} ret
+ * @api private
+ */
+
+function formatRemarketingTag(msg) {
+  var device = msg.proxy('context.device');
+  var app = msg.proxy('context.app');
+  var os = msg.proxy('context.os');
+  var ret = {
+    bundleid: app.namespace,
+    rdid: device.advertisingId,
+    idtype: getIdType(device),
+    lat: device.adTrackingEnabled ? 1 : 0,
+    remarketing_only: 1,
+    appversion: app.version,
+    osversion: os.version
+  };
+
+  // custom properties to remarket with must be prefixed with `data.` property
+  each(function(value, key) {
+    ret['data.' + key] = value;
+  }, msg.properties());
+
+  return ret;
+}
+

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -13,10 +13,10 @@ var each = require('@ndhoule/each');
  */
 
 exports.track = function (msg, settings){
-  var events = settings.events;
   var whitelistedRemarketingEvent = exports.getRemarketingEvent(msg.event(), settings.whitelist);
-  var conversionLabel = exports.getConversionLabel(msg.event(), events);
+  var conversionLabel = exports.getConversionLabel(msg.event(), settings.events);
   var remarketing = settings.remarketing;
+  var remarketingTag;
   var ret = [];
 
   if (conversionLabel) {
@@ -26,7 +26,7 @@ exports.track = function (msg, settings){
 
     // Just like client side, we only send remarketing tags for mapped events
     if (remarketing) {
-      var remarketingTag = formatRemarketingTag(msg);
+      remarketingTag = formatRemarketingTag(msg);
       ret.push(remarketingTag);
     }
   }
@@ -88,7 +88,7 @@ exports.getConversionLabel = function(eventName, events) {
  */
 
 exports.getRemarketingEvent = function(eventName, events) {
-  if (events.indexOf(eventName) > -1) return true;
+  return events.indexOf(eventName) > -1;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-google-adwords",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Google AdWords server-side integration",
   "main": "lib/index.js",
   "scripts": {

--- a/test/fixtures/track-whitelist.json
+++ b/test/fixtures/track-whitelist.json
@@ -1,0 +1,45 @@
+{
+  "input": {
+    "type": "track",
+    "event": "whats gucci",
+    "userId": "user-id",
+    "properties": {
+      "suh": "dude",
+      "cheech": "chong"
+    },
+    "timestamp": "2015-11-09",
+    "context": {
+      "ip": "10.0.0.2",
+      "app": {
+        "namespace": "com.segment.TestApp",
+        "version": "1.0.0",
+        "build": "1.0.0"
+      },
+      "device": {
+        "manufacturer": "some-brand",
+        "type": "ios",
+        "adTrackingEnabled": false,
+        "advertisingId": "159358"
+      },
+      "network": { "carrier": "some-carrier" },
+      "locale": "en-US",
+      "library": {
+        "name": "analytics-ios"
+      },
+      "os": {
+        "version": "1.0.0"
+      }
+    }
+  },
+  "output": {
+    "rdid": "159358",
+    "idtype": "idfa",
+    "lat": "0",
+    "bundleid": "com.segment.TestApp",
+    "appversion": "1.0.0",
+    "osversion": "1.0.0",
+    "data.cheech": "chong",
+    "data.suh": "dude",
+    "remarketing_only": "1"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,8 @@ describe('AdWords', function(){
         'Application Installed': '824NCNfly2cQ4ZPN4gM',
         'Payment Info Added': 'L5vqCITpy2cQ4ZPN4gM'
       },
-      remarketing: false
+      remarketing: false,
+      whitelist: []
     };
 
     googleAdWords = new AdWords(settings);
@@ -31,8 +32,7 @@ describe('AdWords', function(){
     test
       .name('AdWords')
       .endpoint('https://www.googleadservices.com/pagead/conversion/')
-      .channels(['server'])
-      .ensure('settings.events');
+      .channels(['server']);
   });
 
   describe('.validate()', function(){
@@ -65,11 +65,17 @@ describe('AdWords', function(){
     });
 
     it('should be invalid when settings are not complete', function(){
-      delete settings.events;
+      settings.events = {};
       test.invalid(msg, settings);
     });
 
     it('should be valid when settings are complete', function(){
+      test.valid(msg, settings);
+    });
+
+    it('should still be valid if you have no conversion labels but whitelisted remarketing', function(){
+      msg.event = 'remarketing';
+      settings.whitelist.push('remarketing');
       test.valid(msg, settings);
     });
   });
@@ -150,6 +156,22 @@ describe('AdWords', function(){
       test
         .request(1)
         .query(json.output[1])
+        .expects(200);
+
+      test.end(done);
+    });
+
+    it('should send standalone remarketing ping if whitelisted', function(done){
+      googleAdWords.settings.whitelist = ['whats gucci'];
+      var json = test.fixture('track-whitelist');
+
+      test
+        .track(json.input)
+        .requests(1);
+
+      test
+        .request(0)
+        .query(json.output)
         .expects(200);
 
       test.end(done);


### PR DESCRIPTION
@tsholmes @WesleyDRobinson 

**Current behavior**:

You map conversionLabels to Segment events in the settings. If you checked off `remarketing` option, we will also send a remarketing ping for that conversion event. 

**Proposed behavior**:

Customers would like to be able to _just_ send remarketing pings without having to map conversions. This should be an allowable use case since natively you can do so. 

We now have a simple `list` component (checkout integration-repeater in your integrations page) that returns an array of strings we can use. So I'm just checking if a given event is listed in this array of whitelisted events.

I also refactored some.

- [x] [client side parity PR](https://github.com/segment-integrations/analytics.js-integration-adwords/pull/13)
- [ ] metadata
- [ ] site-docs
- [ ] deploy