### PR TITLE
Fix parameters for proper remarketing tracking

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -113,7 +113,7 @@ function formatConversionTag(msg) {
   var ret = {
     rdid: device.advertisingId,
     idtype: getIdType(device),
-    lat: device.adTrackingEnabled ? 1 : 0,
+    lat: device.adTrackingEnabled ? 0 : 1,
     bundleid: app.namespace,
     appversion: app.version,
     osversion: os.version,
@@ -142,8 +142,9 @@ function formatRemarketingTag(msg) {
     bundleid: app.namespace,
     rdid: device.advertisingId,
     idtype: getIdType(device),
-    lat: device.adTrackingEnabled ? 1 : 0,
+    lat: device.adTrackingEnabled ? 0 : 1,
     remarketing_only: 1,
+    usage_tracking_enabled: 1,
     appversion: app.version,
     osversion: os.version
   };


### PR DESCRIPTION
According to the adwords docs the `lat` parameter means `limited ad tracking` and should be set to `1` if the user disabled ad tracking in his iOS settings. In your implementation it is used exactly the other way around. If the user allows ad tracking it was set to `1` whereas it should have been set to `0`.

Also according to the docs the parameter `usage_tracking_enabled` is required, so I added it.

https://developers.google.com/app-conversion-tracking/ios/remarketing-server

This PR refers to the zendesk ticket #69677