### PR TITLE
Fix remarketing settings; update tests to match reality

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+2.3.3 / 2017-03-15
+==================
+
+  * Set LAT parameter to proper values, as they were inverted.
 
 2.3.0 / 2017-01-31
 ==================

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -113,7 +113,7 @@ function formatConversionTag(msg) {
   var ret = {
     rdid: device.advertisingId,
     idtype: getIdType(device),
-    lat: device.adTrackingEnabled ? 1 : 0,
+    lat: device.adTrackingEnabled ? 0 : 1,
     bundleid: app.namespace,
     appversion: app.version,
     osversion: os.version,
@@ -142,8 +142,9 @@ function formatRemarketingTag(msg) {
     bundleid: app.namespace,
     rdid: device.advertisingId,
     idtype: getIdType(device),
-    lat: device.adTrackingEnabled ? 1 : 0,
+    lat: device.adTrackingEnabled ? 0 : 1,
     remarketing_only: 1,
+    usage_tracking_enabled: 1,
     appversion: app.version,
     osversion: os.version
   };

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -144,7 +144,6 @@ function formatRemarketingTag(msg) {
     idtype: getIdType(device),
     lat: device.adTrackingEnabled ? 0 : 1,
     remarketing_only: 1,
-    usage_tracking_enabled: 1,
     appversion: app.version,
     osversion: os.version
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-google-adwords",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Google AdWords server-side integration",
   "main": "lib/index.js",
   "scripts": {

--- a/test/fixtures/track-application-installed-android.json
+++ b/test/fixtures/track-application-installed-android.json
@@ -51,7 +51,7 @@
     "label": "824NCNfly2cQ4ZPN4gM",
     "rdid": "29d7493b-bc9a-4fa9-939b-367c26ac0ec4",
     "idtype": "advertisingid",
-    "lat": 0,
+    "lat": 1,
     "bundleid": "com.segment.TestApp",
     "appversion": "1.0.0",
     "osversion": "5.0",

--- a/test/fixtures/track-application-installed-ios.json
+++ b/test/fixtures/track-application-installed-ios.json
@@ -36,7 +36,7 @@
     "label": "824NCNfly2cQ4ZPN4gM",
     "rdid": "159358",
     "idtype": "idfa",
-    "lat": 1,
+    "lat": 0,
     "bundleid": "com.segment.TestApp",
     "appversion": "1.0.0",
     "osversion": "1.0.0",

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -32,7 +32,7 @@
     "label": "L5vqCITpy2cQ4ZPN4gM",
     "rdid": "159358",
     "idtype": "idfa",
-    "lat": 0,
+    "lat": 1,
     "bundleid": "com.segment.TestApp",
     "appversion": "1.0.0",
     "osversion": "1.0.0",

--- a/test/fixtures/track-remarketing.json
+++ b/test/fixtures/track-remarketing.json
@@ -36,7 +36,7 @@
       "label": "L5vqCITpy2cQ4ZPN4gM",
       "rdid": "159358",
       "idtype": "idfa",
-      "lat": 0,
+      "lat": 1,
       "bundleid": "com.segment.TestApp",
       "appversion": "1.0.0",
       "osversion": "1.0.0",
@@ -47,11 +47,12 @@
     {
       "rdid": "159358",
       "idtype": "idfa",
-      "lat": "0",
+      "lat": 1,
       "bundleid": "com.segment.TestApp",
       "appversion": "1.0.0",
       "osversion": "1.0.0",
       "remarketing_only": 1,
+      "usage_tracking_enabled": 1,
       "data.suh": "dude",
       "data.cheech": "chong"
     }

--- a/test/fixtures/track-remarketing.json
+++ b/test/fixtures/track-remarketing.json
@@ -52,7 +52,6 @@
       "appversion": "1.0.0",
       "osversion": "1.0.0",
       "remarketing_only": 1,
-      "usage_tracking_enabled": 1,
       "data.suh": "dude",
       "data.cheech": "chong"
     }

--- a/test/fixtures/track-whitelist.json
+++ b/test/fixtures/track-whitelist.json
@@ -34,12 +34,13 @@
   "output": {
     "rdid": "159358",
     "idtype": "idfa",
-    "lat": "0",
+    "lat": "1",
     "bundleid": "com.segment.TestApp",
     "appversion": "1.0.0",
     "osversion": "1.0.0",
     "data.cheech": "chong",
     "data.suh": "dude",
-    "remarketing_only": "1"
+    "remarketing_only": "1",
+    "usage_tracking_enabled": "1"
   }
 }

--- a/test/fixtures/track-whitelist.json
+++ b/test/fixtures/track-whitelist.json
@@ -40,7 +40,6 @@
     "osversion": "1.0.0",
     "data.cheech": "chong",
     "data.suh": "dude",
-    "remarketing_only": "1",
-    "usage_tracking_enabled": "1"
+    "remarketing_only": "1"
   }
 }


### PR DESCRIPTION
PR originally made by MattesGroeger, brought locally for CircleCI tests and to update our tests to match intended behavior.

This corrects the reversed ad-tracking features that we had implemented. It also adds the usage_tracking_enabled call where it's necessary. This should bring us up to spec with Adwords' usage.

CC @hankim813 